### PR TITLE
Demonstrate ember-auto-import bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
       "ignoreMissing": [
         "@babel/core"
       ]
+    },
+    "patchedDependencies": {
+      "ember-auto-import@2.6.1": "patches/ember-auto-import@2.6.1.patch"
     }
   },
   "devDependencies": {

--- a/patches/ember-auto-import@2.6.1.patch
+++ b/patches/ember-auto-import@2.6.1.patch
@@ -1,0 +1,13 @@
+diff --git a/js/webpack.js b/js/webpack.js
+index 86641517cc55be2349fbed507ec6f93ebd027469..0b042fd1058cad05498e0eb6aa30a1f551fe508b 100644
+--- a/js/webpack.js
++++ b/js/webpack.js
+@@ -285,7 +285,7 @@ class WebpackBundler extends broccoli_plugin_1.default {
+             if (!context || !request) {
+                 return callback();
+             }
+-            if (request.startsWith('!')) {
++            if (request.startsWith('!') || request.startsWith('-')) {
+                 return callback();
+             }
+             let name = shared_internals_1.packageName(request);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,10 @@
 lockfileVersion: 5.4
 
+patchedDependencies:
+  ember-auto-import@2.6.1:
+    hash: on3orjx5sdrzz67enmzpdgysie
+    path: patches/ember-auto-import@2.6.1.patch
+
 importers:
 
   .:
@@ -102,7 +107,7 @@ importers:
       babel-eslint: 10.1.0_eslint@7.32.0
       broccoli-asset-rev: 3.0.0
       concurrently: 7.6.0
-      ember-auto-import: 2.6.1_webpack@5.76.0
+      ember-auto-import: 2.6.1_on3orjx5sdrzz67enmzpdgysie_webpack@5.76.0
       ember-cli: 4.9.2
       ember-cli-app-version: 5.0.0
       ember-cli-babel: 7.26.11
@@ -188,7 +193,7 @@ importers:
       babel-eslint: 10.1.0_eslint@7.32.0
       broccoli-asset-rev: 3.0.0
       concurrently: 7.6.0
-      ember-auto-import: 2.6.1_webpack@5.76.0
+      ember-auto-import: 2.6.1_on3orjx5sdrzz67enmzpdgysie_webpack@5.76.0
       ember-cli: 4.9.2
       ember-cli-app-version: 5.0.0
       ember-cli-babel: 7.26.11
@@ -276,7 +281,7 @@ importers:
       babel-eslint: 10.1.0_eslint@7.32.0
       broccoli-asset-rev: 3.0.0
       concurrently: 7.6.0
-      ember-auto-import: 2.6.1_webpack@5.76.0
+      ember-auto-import: 2.6.1_on3orjx5sdrzz67enmzpdgysie_webpack@5.76.0
       ember-cli: 4.9.2
       ember-cli-app-version: 5.0.0
       ember-cli-babel: 7.26.11
@@ -1981,7 +1986,7 @@ packages:
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
-      ember-auto-import: 2.6.1_webpack@5.76.0
+      ember-auto-import: 2.6.1_on3orjx5sdrzz67enmzpdgysie_webpack@5.76.0
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.2
@@ -2010,7 +2015,7 @@ packages:
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
-      ember-auto-import: 2.6.1_webpack@5.76.0
+      ember-auto-import: 2.6.1_on3orjx5sdrzz67enmzpdgysie_webpack@5.76.0
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - supports-color
@@ -2038,7 +2043,7 @@ packages:
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
-      ember-auto-import: 2.6.1_webpack@5.76.0
+      ember-auto-import: 2.6.1_on3orjx5sdrzz67enmzpdgysie_webpack@5.76.0
       ember-cached-decorator-polyfill: 1.0.1_ember-source@4.9.3
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
@@ -2100,7 +2105,7 @@ packages:
       '@ember-data/store': 4.9.1_q466kjsaf7mmub7jg57vkyehbq
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.10.0
-      ember-auto-import: 2.6.1_webpack@5.76.0
+      ember-auto-import: 2.6.1_on3orjx5sdrzz67enmzpdgysie_webpack@5.76.0
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - supports-color
@@ -2123,7 +2128,7 @@ packages:
       '@ember-data/store': 4.9.1_q466kjsaf7mmub7jg57vkyehbq
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
-      ember-auto-import: 2.6.1_webpack@5.76.0
+      ember-auto-import: 2.6.1_on3orjx5sdrzz67enmzpdgysie_webpack@5.76.0
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-inflector: 4.0.2
@@ -2155,7 +2160,7 @@ packages:
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
       '@glimmer/tracking': 1.1.2
-      ember-auto-import: 2.6.1_webpack@5.76.0
+      ember-auto-import: 2.6.1_on3orjx5sdrzz67enmzpdgysie_webpack@5.76.0
       ember-cached-decorator-polyfill: 1.0.1_ember-source@4.9.3
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
@@ -2849,7 +2854,7 @@ packages:
     dev: true
 
   /@types/eslint/7.29.0:
-    resolution: {integrity: sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==, tarball: '@types/eslint/-/eslint-7.29.0.tgz'}
+    resolution: {integrity: sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==}
     dependencies:
       '@types/estree': 1.0.0
       '@types/json-schema': 7.0.11
@@ -5984,7 +5989,7 @@ packages:
     resolution: {integrity: sha512-DIk2H4g/3ZhjgiABJjVdQvUdMlSABOsjeCm6gmUzIdKxAuFrGiJ8QXMm3i09grZdDBMC/d8MELMrdwYRC0+YHg==}
     dev: true
 
-  /ember-auto-import/2.6.1_webpack@5.76.0:
+  /ember-auto-import/2.6.1_on3orjx5sdrzz67enmzpdgysie_webpack@5.76.0:
     resolution: {integrity: sha512-3bCRi/pXp4QslmuCXGlSz9xwR7DF5oDx3zZO5OXKzNZihtkqAM1xvGuRIdQSl46pvbAXOkp8Odl5fOen1i0dRw==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
@@ -6022,6 +6027,7 @@ packages:
       - supports-color
       - webpack
     dev: true
+    patched: true
 
   /ember-cache-primitive-polyfill/1.0.1:
     resolution: {integrity: sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==}
@@ -6536,7 +6542,7 @@ packages:
       '@embroider/macros': 1.10.0
       '@glimmer/env': 0.1.7
       broccoli-merge-trees: 4.2.0
-      ember-auto-import: 2.6.1_webpack@5.76.0
+      ember-auto-import: 2.6.1_on3orjx5sdrzz67enmzpdgysie_webpack@5.76.0
       ember-cli-babel: 7.26.11
       ember-inflector: 4.0.2
     transitivePeerDependencies:
@@ -6628,7 +6634,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
-      ember-auto-import: 2.6.1_webpack@5.76.0
+      ember-auto-import: 2.6.1_on3orjx5sdrzz67enmzpdgysie_webpack@5.76.0
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.0.0
       ember-source: 4.9.3_umjy2qep55frc2p7bsvims6xpm
@@ -6699,7 +6705,7 @@ packages:
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
-      ember-auto-import: 2.6.1_webpack@5.76.0
+      ember-auto-import: 2.6.1_on3orjx5sdrzz67enmzpdgysie_webpack@5.76.0
       ember-cli-babel: 7.26.11
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0


### PR DESCRIPTION
This is the explanation for the v2 addon failure under a classic build.

ember-auto-import's externals handler is incorrectly identifying the prefixed form of the import that css-loader emits as a package name.

